### PR TITLE
CASMTRIAGE-1950: Fix type error with max backoff option

### DIFF
--- a/src/batcher/__main__.py
+++ b/src/batcher/__main__.py
@@ -61,11 +61,15 @@ def main():
 
     manager = BatchManager()
     while True:
-        sleep(options.batcher_check_interval)
-        options.update()
-        manager.check_status()
-        manager.update_batches()
-        manager.send_batches()
+        try:
+            sleep(options.batcher_check_interval)
+            options.update()
+            manager.check_status()
+            manager.update_batches()
+            manager.send_batches()
+        except Exception as e:
+            LOGGER.error('Unexpected error occurred: {}'.format(e))
+            sleep(5)  # Arbitrary sleep to prevent recurring errors from hammering other services.
 
 
 if __name__ == '__main__':

--- a/src/batcher/cfs/options.py
+++ b/src/batcher/cfs/options.py
@@ -113,7 +113,7 @@ class Options():
 
     @property
     def max_backoff(self):
-        return self.get_option('batcherMaxBackoff', str)
+        return self.get_option('batcherMaxBackoff', int)
 
 
 options = Options()


### PR DESCRIPTION
### Summary and Scope

Fixes an issue where the max backoff value was cast as a string, making a "min" comparison fail.  Also updated the main loop so that errors like this don't stop batcher from running entirely.

### Issues and Related PRs

* Resolves CASMTRIAGE-1950

### Testing

Tested on:

* Odin

Deployed the updated image and the batcher was able to move past the error and keep running.

### Risks and Mitigations

None