### PR TITLE
CASMCMS-7607: Add detection of sessions stuck in pending

### DIFF
--- a/src/batcher/cfs/sessions.py
+++ b/src/batcher/cfs/sessions.py
@@ -95,6 +95,19 @@ def create_session(config, config_limit='', components=[], tags=None):
     return success, name
 
 
+def delete_session(name):
+    """Create a configuration (CFS) session"""
+    url = ENDPOINT + '/' + name
+    session = requests_retry_session()
+    try:
+        response = session.delete(url)
+        response.raise_for_status()
+    except (ConnectionError, MaxRetryError) as e:
+        LOGGER.error("Unable to connect to CFS: {}".format(e))
+    except HTTPError as e:
+        LOGGER.error("Unexpected response from CFS: {}".format(e))
+
+
 def get_session_status(name):
     """Get the status for configuration (CFS) session"""
     data = get_session(name)


### PR DESCRIPTION
### Summary and Scope

Adds handling CFS sessions that get stuck in pending state.

In rare situations such as power outages, it is possible for a CFS session to be created that never makes it out of the pending state because communication is disrupted between Kafka and the cfs-operator.  If the session is created by the cfs-batcher, it can then block future configuration of the affected components since cfs-batcher will not configure multiple sessions to run against the same nodes.  This adds detection and removal of such sessions, paving the way for retries or other configuration attempts.

This does not address stuck sessions created directly by users.  These are less common and fewer, so the situation is less likely, these do not block other sessions, so there is no risk of confusion from configuration that won't start, and there are no retries, so removing sessions would be more confusing since it would appear the session created by the user disappeared.

### Issues and Related PRs

* Resolves CASMCMS-7607

### Testing

Tested on:

* Mug

Took down the cfs-operator to simulate the sort of failure that can cause this situation, and then created sessions.  Also tested restarting the batcher so that it loads old state.

### Risks and Mitigations

None