### PR TITLE
CASMCMS-8252: Update Chart with correct version strings during builds; enable unstable artifact builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Spelling corrections.
+- Update Chart with correct image and chart version strings during builds.
 
 ## [1.7.35] 2022-03-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Pending session timeout is now configurable using an option
 - Logging level is now controlled by a CFS option
+- Enabled building of unstable artifacts
+- Updated header of update_versions.conf to reflect new tool options
 
 ### Fixed
 - Spelling corrections.

--- a/kubernetes/cray-cfs-batcher/Chart.yaml
+++ b/kubernetes/cray-cfs-batcher/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-cfs-batcher
-version: 0.0.0
+version: 0.0.0-chart
 description: Kubernetes resources for cfs-batcher
 keywords:
 - cfs
@@ -39,9 +39,9 @@ dependencies:
 maintainers:
 - name: rbak-hpe
   email: ryan.bak@hpe.com
-appVersion: 0.0.0
+appVersion: 0.0.0-image
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs-batcher
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs-batcher:0.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-cfs-batcher:0.0.0-image
   artifacthub.io/license: MIT

--- a/kubernetes/cray-cfs-batcher/Chart.yaml
+++ b/kubernetes/cray-cfs-batcher/Chart.yaml
@@ -43,5 +43,5 @@ appVersion: 0.0.0-image
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs-batcher
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs-batcher:0.0.0-image
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-batcher:0.0.0-image
   artifacthub.io/license: MIT

--- a/kubernetes/cray-cfs-batcher/values.yaml
+++ b/kubernetes/cray-cfs-batcher/values.yaml
@@ -37,7 +37,7 @@ cray-service:
     cray-cfs-batcher:
       name: cray-cfs-batcher
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-batcher
+        repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-batcher
         # tag defaults to chart appVersion
       ports:
       - name: http

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,5 +15,10 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
-tag: 0.0.0
+sourcefile: .chart_version
+tag: 0.0.0-chart
+targetfile: kubernetes/cray-cfs-batcher/Chart.yaml
+
+sourcefile: .docker_version
+tag: 0.0.0-image
 targetfile: kubernetes/cray-cfs-batcher/Chart.yaml

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -22,3 +22,8 @@ targetfile: kubernetes/cray-cfs-batcher/Chart.yaml
 sourcefile: .docker_version
 tag: 0.0.0-image
 targetfile: kubernetes/cray-cfs-batcher/Chart.yaml
+
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
+targetfile: kubernetes/cray-cfs-batcher/Chart.yaml
+targetfile: kubernetes/cray-cfs-batcher/values.yaml


### PR DESCRIPTION
## Summary and Scope

### Use correct version strings

After Ryan noticed that a CFS build of his was not using the expected version strings in the Chart artifact, we looked into it and discovered that this was because the build was taking the docker and chart version strings from the wrong source. Specifically, it was taking them from the .version file, which did not include the "beta" tag that he was expecting. It should have been getting the docker and chart version strings from .docker_version and .chart_version respectively.

For tagged builds on the master branch, there is no difference in the contents of those files. But if doing builds in release branches, for example, the difference is apparent. 

I corrected the issue in the CFS repo with this PR:
https://github.com/Cray-HPE/config-framework-service/pull/51

I then reviewed all of the other CMS repos to see if the problem existed in any of them. I identified several others with the same issue. This PR is addressing the issue for this repository.

### Enable unstable artifacts

Currently the Chart.yaml and values.yaml files are hard-coded to point to stable directories on artifactory. The problem comes if an unstable artifact is built. That version of the docker image won't exist in that location out on artifactory, making the unstable chart unusable.

The fix is to adjust the path to stable or unstable based on the type of build being done. This was done in the BOS repo [with this PR](https://github.com/Cray-HPE/bos/pull/57) and in the CFS repo [with this PR](https://github.com/Cray-HPE/config-framework-service/pull/52).

I am making the change to this repository with this PR.

## Issues and Related PRs

* https://github.com/Cray-HPE/cms-ipxe/pull/51
* https://github.com/Cray-HPE/cfs-batcher/pull/40
* https://github.com/Cray-HPE/console-node/pull/63
* https://github.com/Cray-HPE/console-data/pull/35
* https://github.com/Cray-HPE/console-operator/pull/38
* https://github.com/Cray-HPE/image-recipes/pull/32
* https://github.com/Cray-HPE/cms-tftpd/pull/36
* https://github.com/Cray-HPE/csm-ssh-keys/pull/21
* https://github.com/Cray-HPE/config-framework-service/pull/51
* https://github.com/Cray-HPE/config-framework-service/pull/52
* https://github.com/Cray-HPE/bos/pull/57

## Testing

None beyond making sure the build works and the artifacts get the correct version strings and paths.

## Risks and Mitigations

Very low risk. For master branch stable artifacts, this change has no effect.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
