### PR TITLE
CASMCMS-8716: Update some dependency patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Removed
 - Removed defunct files leftover from previous versioning system
+### Dependencies
+Bumped dependency patch versions:
+| Package                  | From     | To       |
+|--------------------------|----------|----------|
+| `kubernetes`             | 9.0.0    | 9.0.1    |
+| `rsa`                    | 4.7      | 4.7.2    |
+| `urllib3`                | 1.25.9   | 1.25.11  |
 
 ## [1.8.0] - 1/12/2023
 ### Added

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
-kubernetes==9.0.0
+kubernetes==9.0.1
 requests==2.22.0
 wget==3.2
-rsa==4.7
-urllib3==1.25.9
+rsa==4.7.2
+urllib3==1.25.11


### PR DESCRIPTION
## Summary and Scope

When working on recent CVEs I noticed that a number of dependencies in some of our repos have newer patch versions available that are fully backward compatible, containing mostly bug fixes.

## Issues and Related PRs

* Resolves [CASMCMS-8716](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8716) for this repo

## Testing

None beyond reviewing the patch release notes and making sure that the build worked.

## Risks and Mitigations

Low risk -- these are only patch version bumps, and not very large ones.
