### PR TITLE
CASMTRIAGE-6131: CFS configuration limit field should be comma-delimited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.9.1] - 10/05/2023
+### Fixed
+- When specifying a configuration limit field for a session, use commas to delimit the
+  layers (as per the API spec)
+
 ## [1.9.0] - 8/18/2023
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/src/batcher/component.py
+++ b/src/batcher/component.py
@@ -37,8 +37,8 @@ class Component(object):
         self.error_count = data['error_count']
         self.tags = data.get('tags', {})
         self.config_name = data['desired_config']
-        # config_limit - The layers that still need to be configured
-        self.config_limit = ''.join([str(i) for i, layer in enumerate(data.get('desired_state', []))
+        # config_limit - Comma-delimited string listing the layers that still need to be configured
+        self.config_limit = ','.join([str(i) for i, layer in enumerate(data.get('desired_state', []))
                                      if layer.get('status', '').lower() == 'pending'])
         # latest_status/timestamp - Identifies if the most recent config attempt was failed/incomplete
         #   and when the most recent state was recorded


### PR DESCRIPTION
## Summary and Scope

[CASMTRIAGE-6131](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6131) was open because a CFS session skipped every layer in the configuration it was supposed to apply. This session was one automatically created by batcher, not by the user. Investigating, I saw that the session contained this:

```json
"configuration": {
    "limit": "0123456",
    "name": "fullstack-management-23.11_WIP-220504"
  }
```

But the CFS API spec says that this `limit` field should be comma-delimited:

```yaml
    SessionConfigurationSection: 
      type: object
      description: The configuration information which the session will apply
      properties: 
        name: 
          type: string
          description: The name of the CFS configuration to be applied
          example: example-config
        limit: 
          type: string
          description: >-
            A comma separated list of layers in the configuration to limit the session to.
            This can be either a list of named layers, or a list of indices.
          example: layer1,layer3
```

Manually creating the session using a comma-delimited list worked fine.

[A recent PR](https://github.com/Cray-HPE/cfs-batcher/pull/52) (for [CASMCMS-5793](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-5793)) made a lot of changes, including one which accidentally changes CFS batcher to stop delimiting this field using commas. This PR changes CFS batcher so that it once again creates comma-delimited lists for that field.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6131](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6131)
* Bug injected by
  * [PR](https://github.com/Cray-HPE/cfs-batcher/pull/52)
  * [CASMCMS-5793](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-5793)

## Testing

Applied the fix on slice (where the problem was reported), then cleared the state of one of the nodes. The session created by batcher correctly comma-delimited the field:

```text
ncn-m001:~ # cray cfs sessions describe batcher-15ba81a0-d061-4d73-8de2-fec1b85de882 --format json | jq .configuration.limit
"0,1,2,3,4,5,6"
```

## Risks and Mitigations

Without this, CFS batcher is sad.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
