### PR TITLE
CASMTRIAGE-6490: Add error handling during starup state rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.9.2] - 01/10/2024
+### Fixed
+- Improved error handling during the rebuild state phase of startup
+
 ## [1.9.1] - 10/05/2023
 ### Fixed
 - When specifying a configuration limit field for a session, use commas to delimit the

--- a/src/batcher/batch.py
+++ b/src/batcher/batch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -69,7 +69,12 @@ class BatchManager(object):
         self.current_backoff = 0
         self.backoff_start = 0
         # If the batcher is restarted, state will need to be rebuilt.
-        self._rebuild_state()
+        while True:
+            try:
+                self._rebuild_state()
+                break
+            except:
+                LOGGER.warning("Rebuilding state was interrupted. Trying again...")
 
     def check_status(self):
         """Remove batches for which the sessions have been completed"""

--- a/src/batcher/cfs/sessions.py
+++ b/src/batcher/cfs/sessions.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -78,10 +78,13 @@ def get_sessions(parameters=None):
         return json.loads(response.text)
     except (ConnectionError, MaxRetryError) as e:
         LOGGER.error("Unable to connect to CFS: {}".format(e))
+        raise e
     except HTTPError as e:
         LOGGER.error("Unexpected response from CFS: {}".format(e))
+        raise e
     except json.JSONDecodeError as e:
         LOGGER.error("Non-JSON response from CFS: {}".format(e))
+        raise e
     return None
 
 


### PR DESCRIPTION
## Summary and Scope

Fixes an issue where an unlucky error from the cfs-api during startup can cause cfs-batcher to get stuck and not schedule batches.

## Issues and Related PRs

* Resolves CASMTRIAGE-6490

## Testing

### Tested on:

  * Fanta

### Test description:

Successfully deployed cfs-batcher

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

