### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Dependencies
+- Bump `kubernetes` from 9.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version
+
 ## [1.9.2] - 01/10/2024
 ### Fixed
 - Improved error handling during the rebuild state phase of startup

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,7 @@
-kubernetes==9.0.1
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 requests==2.22.0
-wget==3.2
 rsa==4.7.2
 ujson==5.8.0
 urllib3==1.25.11
+wget==3.2


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
