### PR TITLE
CASMTRIAGE-7233: Use requests-retry-session module to avoid potential hang and duplicated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add code to heartbeat thread that causes it to bail if the main thread is no longer alive.
+
 ### Dependencies
 - Use `requests_retry_session` module instead of duplicating the code.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- Use `requests_retry_session` module instead of duplicating the code.
+
 ## [1.10.0] - 02/22/2024
 ### Dependencies
 - Bump `kubernetes` from 9.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,8 +29,8 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev && \
 	apk -U upgrade --no-cache && \
-    pip3 install --no-cache-dir -U pip && \
-    pip3 install --no-cache-dir -r requirements.txt
+    pip3 install --no-cache-dir -U pip
+RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir -r requirements.txt
 COPY src/batcher/ lib/batcher/
 
 # Testing Image
@@ -53,4 +53,3 @@ FROM base as application
 USER nobody:nobody
 ENV PYTHONPATH "/app/lib/"
 ENTRYPOINT [ "python3", "-m", "batcher" ]
-

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,7 @@
 # CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
 kubernetes==22.6.0
 requests==2.22.0
+requests_retry_session>=0.1,<0.2
 rsa==4.7.2
 ujson==5.8.0
 urllib3==1.25.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
+--trusted-host arti.hpc.amslabs.hpecorp.net
+--trusted-host artifactory.algol60.net
+--index-url https://arti.hpc.amslabs.hpecorp.net:443/artifactory/api/pypi/pypi-remote/simple
+--extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 
 kubernetes
 requests
+requests_retry_session
 wget
 ujson

--- a/src/batcher/__main__.py
+++ b/src/batcher/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,7 @@ from .cfs.options import options
 
 DEFAULT_LOG_LEVEL = logging.INFO
 LOGGER = logging.getLogger(__name__)
+MAIN_THREAD = threading.current_thread()
 
 
 def monotonic_liveliness_heartbeat():
@@ -45,6 +46,9 @@ def monotonic_liveliness_heartbeat():
     period of time.
     """
     while True:
+        if not MAIN_THREAD.is_alive():
+            # All hope abandon ye who enter here
+            return
         Timestamp()
         sleep(10)
 

--- a/src/batcher/client.py
+++ b/src/batcher/client.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,24 +21,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from functools import partial
+
+from requests_retry_session import requests_retry_session as base_requests_retry_session
+
 from . import PROTOCOL
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
-
-def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
-                           status_forcelist=(500, 502, 503, 504),
-                           session=None):
-    session = session or requests.Session()
-    retry = Retry(
-        total=retries,
-        read=retries,
-        connect=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount(PROTOCOL, adapter)
-    return session
+requests_retry_session = partial(base_requests_retry_session, protocol=PROTOCOL)


### PR DESCRIPTION
This triage ticket was opened because cfs-batcher was hung on a CSM 1.6 system. It seems that an API request made by batcher got hung, causing the entire service to effectively hang. This is the same problem that had been seen with some BOS operators, leading to [CASMCMS-8752](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8752). That ticket introduced two changes to the BOS operators:

1. Added a timeout to their API requests
2. Added a check in the heartbeat thread that exited if the main thread was no longer alive.

This PR does both for cfs-batcher. For the first one, though, it does this by using a [new CSM Python module](https://github.com/Cray-HPE/requests-retry-session/tree/develop/requests_retry_session) that contains the requests-retry-session code. This is because this same code is reused in a number of places, and as this triage ticket demonstrates, we are not good about fixing all of them when we spoke a bug or flaw in it. I plan to make additional PRs to the other repos which currently replicate this code, so they can instead use the module, and we can confine our fixes to that repo.

I tested these changes on mug and verified that no problems were seen.