### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 02/13/2025
+### Dependencies
+- CASMCMS-9282
+  - Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
+  - Use Pytyhon venv inside Docker image
+  - Update Python dependencies for move to Python 3.12
+
 ## [1.12.0] - 09/03/2024
 ### Dependencies
 - CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,15 +22,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Base image
-FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
+FROM artifactory.algol60.net/docker.io/alpine:3.21 as base
 WORKDIR /app
+ENV VIRTUAL_ENV=/app/venv
 COPY constraints.txt requirements.txt ./
 RUN apk add --upgrade --no-cache apk-tools &&  \
-	apk update && \
-	apk add --no-cache gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev && \
-	apk -U upgrade --no-cache && \
-    pip3 install --no-cache-dir -U pip
-RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir -r requirements.txt
+    apk update && \
+    apk add --no-cache gcc g++ python3 python3-dev py3-pip musl-dev libffi-dev openssl-dev && \
+    apk -U upgrade --no-cache && \
+    python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --no-cache-dir -U pip -c constraints.txt && \
+    pip3 install --no-cache-dir --disable-pip-version-check -U setuptools wheel -c constraints.txt && \
+    pip3 install --no-cache-dir --disable-pip-version-check -r requirements.txt && \
+    pip3 list --format freeze
 COPY src/batcher/ lib/batcher/
 
 # Testing Image
@@ -39,7 +45,8 @@ WORKDIR /app/
 COPY src/test lib/test/
 COPY docker_test_entry.sh .
 COPY test-requirements.txt .
-RUN pip3 install --no-cache-dir -r test-requirements.txt
+RUN pip3 install --no-cache-dir -r test-requirements.txt && \
+    pip3 list --format freeze
 CMD [ "./docker_test_entry.sh" ]
 
 # Codestyle reporting

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,8 +1,8 @@
 # CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
 kubernetes>=24.2,<24.3
-requests==2.22.0
-requests_retry_session>=0.1,<0.2
-rsa==4.7.2
+requests>=2.31,<2.32
+requests-retry-session>=1.0,<1.1
+rsa>=4.7.2,<4.8
 ujson==5.8.0
-urllib3==1.25.11
+urllib3>=1.26,<1.27
 wget==3.2


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.

Moving to Alpine 3.19+ required minor Dockerfile rework to install the Python packages into a virtual environment.