### PR TITLE
CASMCMS-9641: Updated ujson from 5.8 to 5.12 to resolve CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9641: Updated `ujson` from `5.8` to `5.12` to resolve CVEs:
+  - https://snyk.io/vuln/SNYK-PYTHON-UJSON-15682605
+  - https://snyk.io/vuln/SNYK-PYTHON-UJSON-15682606
+
 ## [1.14.0] - 03/17/2026
 ### Changed
 - CASMCMS-9631: Include stack trace when logging exceptions in main execution loop

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,6 +8,6 @@ requests-retry-session>=3.0,<3.1    ; python_version >= '3.11' and python_versio
 requests-retry-session>=4.0,<4.1    ; python_version >= '3.12' and python_version < '3.13'
 requests-retry-session>=5.0,<5.1    ; python_version >= '3.13'
 rsa>=4.7.2,<4.8
-ujson==5.8.0
+ujson>=5.12,<5.13
 urllib3>=2.6.3,<2.7
 wget==3.2


### PR DESCRIPTION
I tested this on surtur (1.7.1). In addition the `cmsdev` suite, I also cleared the component status for an NCN, and verified that batcher and operator worked correctly to create and run the resulting CFS session.

(I tested this simultaneously with https://github.com/Cray-HPE/cfs-operator/pull/174)